### PR TITLE
build: QoL imrpovements

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 echo -e "\e[93mC-Wordle Game - Coded By v3l0r3k\e[0m"
 echo
 echo [+] Attempting to compile game...
-gcc cwordle.c -Wall -Wextra -o cw
 echo gcc cwordle.c -Wall -Wextra -o cw
+gcc cwordle.c -Wall -Wextra -o cw
 echo
 echo -e "Run as \e[93m./cw\e[0m" 
 echo Enjoy it!


### PR DESCRIPTION
 * Marked script as executable so you can run it with ./build.sh
 * It now echos the command before running it, so that if it takes a while to run, you know what it's doing.
   A better approach for this would maybe be to `set -ex` at the beginning of the script? Though I think you'd also have to remove all the 'echo's